### PR TITLE
validate-release: Only check x86_64 for 4.13 and earlier

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -124,7 +124,13 @@ func (o *Options) Run(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse version: %w", err)
 		}
-		for _, suffix := range []ArchTagSuffix{ArchTagSuffixAMD64, ArchTagSuffixARM64, ArchTagSuffixS390x, ArchTagSuffixPPC64LE} {
+		// For 4.13 and earlier, only check x86_64 as multi-arch support was limited
+		// For 4.14+, check all architectures
+		archSuffixes := []ArchTagSuffix{ArchTagSuffixAMD64, ArchTagSuffixARM64, ArchTagSuffixS390x, ArchTagSuffixPPC64LE}
+		if version.Major == 4 && version.Minor <= 13 {
+			archSuffixes = []ArchTagSuffix{ArchTagSuffixAMD64}
+		}
+		for _, suffix := range archSuffixes {
 			image := fmt.Sprintf("quay.io/openshift-release-dev/ocp-release:%s-%s", versionStr, string(suffix))
 			c, err := getCincinnatiMetadata(image)
 			if err != nil {


### PR DESCRIPTION
For OpenShift 4.13 and earlier versions, multi-arch support was limited, so only validate the x86_64 architecture. For 4.14 and later, validate all architectures (x86_64, aarch64, s390x, ppc64le).

This allows the validate-release test to pass for 4.13 releases without requiring all architecture images to exist.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED